### PR TITLE
Improve search functionality by adding Search All & Ignore diacritics

### DIFF
--- a/scribus/appmodehelper.cpp
+++ b/scribus/appmodehelper.cpp
@@ -215,11 +215,20 @@ void AppModeHelper::setApplicationMode(ScribusMainWindow* scmw, ScribusDoc* doc,
 		case modeNormal:
 			{
 				bool editSearchReplace = false;
-				if (currItem != 0)
+				//enable search if at least one text frame is in the document
+				if (doc->Items->count() != 0)
 				{
-					editSearchReplace |= currItem->isTextFrame();
-					editSearchReplace |= (currItem->itemText.length() > 0);
-					editSearchReplace |= (doc->m_Selection->count() == 1);
+					for (int i = 0; i < doc->Items->count(); i++)
+					{
+						if (doc->Items->at(i)->isTextFrame())
+						{
+							if (doc->Items->at(i)->itemText.length() > 0)
+							{
+								editSearchReplace = true;
+								break;
+							}
+						}
+					}
 				}
 				(*a_scrActions)["editSearchReplace"]->setEnabled(editSearchReplace);
 
@@ -525,7 +534,24 @@ void AppModeHelper::enableActionsForSelection(ScribusMainWindow* scmw, ScribusDo
 			(*a_scrActions)["editCut"]->setEnabled(false);
 			(*a_scrActions)["editCopy"]->setEnabled(false);
 			(*a_scrActions)["editCopyContents"]->setEnabled(false);
-			(*a_scrActions)["editSearchReplace"]->setEnabled(false);
+			//enable search and replace if at least one text frame is in the document
+			if (doc->Items->count() != 0)
+			{
+				for (int i = 0; i < doc->Items->count(); i++)
+				{
+					if (doc->Items->at(i)->isTextFrame())
+					{
+						if (doc->Items->at(i)->itemText.length() > 0)
+						{
+							(*a_scrActions)["editSearchReplace"]->setEnabled(true);
+							break;
+						}
+					}
+				}
+			}
+			else
+				(*a_scrActions)["editSearchReplace"]->setEnabled(false);
+
 			(*a_scrActions)["extrasHyphenateText"]->setEnabled(false);
 			(*a_scrActions)["extrasDeHyphenateText"]->setEnabled(false);
 

--- a/scribus/scribus.cpp
+++ b/scribus/scribus.cpp
@@ -8456,12 +8456,77 @@ void ScribusMainWindow::EditTabs()
 
 void ScribusMainWindow::SearchText()
 {
-	PageItem *currItem = doc->m_Selection->itemAt(0);
+	PageItem *currItem = NULL;
+	bool SearchCur = false;
+	bool flag = false;
+
+	/*
+	 * The currItem is selected based on:
+	 * 1- first text frame selected.
+	 * if not
+	 *	select first text frame in current page.
+	 * if not
+	 *	got to next page and select the first text frame
+	 * if you reach the end of the document
+	 *	start from the first page.
+	 */
+	if (doc->Items->count() == 0)
+		return;
+	else if (doc->m_Selection->count() > 0)
+	{
+		//start searching from the selected text frame
+		for (int i = 0 ; i < doc->m_Selection->count(); i++)
+			if (doc->m_Selection->itemAt(i)->isTextFrame() && doc->m_Selection->itemAt(i)->itemText.length() > 0 )
+			{
+				flag = true;
+				currItem = doc->m_Selection->itemAt(i);
+				if (doc->m_Selection->count() == 1)
+					SearchCur = true;
+				break;
+			}
+	}
+	// if no text frame selected
+	if (!flag)
+	{
+		int i = 0;
+		int j = 0;
+		//find current page index
+		for (i = 0; i < doc->Items->count(); i++)
+		{
+			if (doc->Items->at(i)->OwnPage >= doc->currentPageNumber())
+				break;
+		}
+		j = i;
+		//start from current page  till the end of the document
+		for (i = j; i < doc->Items->count(); i++)
+		{
+			if (doc->Items->at(i)->isTextFrame() && doc->Items->at(i)->itemText.length() > 0)
+			{
+				flag= true;
+				currItem = doc->Items->at(i);
+				break;
+			}
+		}
+		//if reached the end of the document start from beggining
+		if (!flag)
+			for (i = 0; i < j; i++)
+			{
+				if (doc->Items->at(i)->isTextFrame() && doc->Items->at(i)->itemText.length() > 0)
+				{
+					currItem = doc->Items->at(i);
+					break;
+				}
+			}
+	}
+
+	doc->m_Selection->addItem(currItem);
+	//PageItem *currItem = doc->m_Selection->itemAt(0);
 	view->requestMode(modeEdit);
-	currItem->itemText.setCursorPosition(0);
-	SearchReplace* dia = new SearchReplace(this, doc, currItem);
+	currItem->itemText.setCursorPosition(currItem->firstInFrame());
+	SearchReplace* dia = new SearchReplace(this, doc, currItem, true , SearchCur);
 	connect(dia, SIGNAL(NewFont(const QString&)), this, SLOT(SetNewFont(const QString&)));
 	connect(dia, SIGNAL(NewAbs(int)), this, SLOT(setAlignmentValue(int)));
+	connect(dia, SIGNAL(selectElementByItem(PageItem*,bool)), this, SLOT(selectItemsFromOutlines(PageItem*, bool)));
 	dia->exec();
 	dia->disconnect();
 	delete dia;

--- a/scribus/scribus.cpp
+++ b/scribus/scribus.cpp
@@ -8526,7 +8526,6 @@ void ScribusMainWindow::SearchText()
 	SearchReplace* dia = new SearchReplace(this, doc, currItem, true , SearchCur);
 	connect(dia, SIGNAL(NewFont(const QString&)), this, SLOT(SetNewFont(const QString&)));
 	connect(dia, SIGNAL(NewAbs(int)), this, SLOT(setAlignmentValue(int)));
-	connect(dia, SIGNAL(selectElementByItem(PageItem*,bool)), this, SLOT(selectItemsFromOutlines(PageItem*, bool)));
 	dia->exec();
 	dia->disconnect();
 	delete dia;

--- a/scribus/text/specialchars.cpp
+++ b/scribus/text/specialchars.cpp
@@ -263,17 +263,13 @@ bool SpecialChars::isIgnorableCodePoint(uint ch)
 		return false;
 }
 
-bool SpecialChars::isArabicDiacritic(uint ch)
+bool SpecialChars::isArabicModifierLetter(uint ch)
 {
-	if (ch >= 0x064B && ch <= 0x065F) /*Fathatan, Dammatan, Kasratan, Fatha,Damma,Kasra,Shadda,Sukun,Maddah, Hamza Above, Hamza Below,Subscript Alef,Inverted Damma,Mark Noon Ghunna*/
+	if (ch == 0x0640) //ARABIC TATWEEL
 		return true;
-	else if (ch == 0x0640) //Tatweel
+	else if (ch == 0x06E5) //ARABIC SMALL WAW
 		return true;
-	else if (ch >= 0x06D2 && ch <= 0x06DC) /*Yeh Barree,Yeh Barree With Hamza Above, Full Stop Ae,Sad With Lam With Alef,Qaf With Lam With Alef,Small High Meem Initial Form, Small High Lam Alef, Small High Jeem , Small High Three Dots, Small High Seen */
-		return true;
-	else if (ch >= 0x06DF && ch <= 0x06E8) /*Small High Rounded Zero, Upright Rectangular Zero,Dotless Head Of Khah,Meem Isolated Form, Small Low Seen, Small High Madda,Small Waw, Small Yeh, Small High Yeh, Small High Noon */
-		return true;
-	else if (ch >= 0x0618 && ch <= 0x061A) /*Small Fatha, Small Damma, Small Kasra*/
+	else if (ch == 0x06E6) //ARABIC SMALL YEH
 		return true;
 	return false;
 }

--- a/scribus/text/specialchars.h
+++ b/scribus/text/specialchars.h
@@ -81,7 +81,7 @@ public:
 	static bool isCJK(uint ch);
 	static bool isLetterRequiringSpaceAroundCJK(uint ch);
 	static bool isIgnorableCodePoint(uint ch);
-	static bool isArabicDiacritic(uint ch);
+	static bool isArabicModifierLetter(uint ch);
 };
 
 #endif

--- a/scribus/text/storytext.h
+++ b/scribus/text/storytext.h
@@ -30,6 +30,7 @@ pageitem.cpp  -  description
 #include <QList>
 #include <cassert>
 #include "unicode/brkiter.h"
+#include <unicode/translit.h>
 #include "itextsource.h"
 
 #include "marks.h"
@@ -303,6 +304,7 @@ private:
 	static BreakIterator* m_wordIterator;
 	static BreakIterator* m_sentenceIterator;
 	static BreakIterator* m_lineIterator;
+	static Transliterator* m_transliterator;
 //	int m_firstFrameItem, m_lastFrameItem;
 //	QList<LineSpec> m_lines;
 //	bool m_validLayout;

--- a/scribus/text/storytext.h
+++ b/scribus/text/storytext.h
@@ -104,8 +104,11 @@ class SCRIBUS_API StoryText : public QObject, public SaxIO, public ITextSource
  	void clear();
 	StoryText copy() const;
 
+	// Find and select text in story
+	int find(const QString &str, int from = 0, Qt::CaseSensitivity cs = Qt::CaseSensitive);
+
 	// Find text in story
-	int indexOf(const QString &str, int from = 0, Qt::CaseSensitivity cs = Qt::CaseSensitive) const;
+	int indexOf(const QString &str, int from = 0, Qt::CaseSensitivity cs = Qt::CaseSensitive, int* pLen = 0) const;
 	int indexOf(QChar ch, int from = 0, Qt::CaseSensitivity cs = Qt::CaseSensitive) const;
 	
 	// Add, change, replace

--- a/scribus/ui/search.cpp
+++ b/scribus/ui/search.cpp
@@ -776,9 +776,9 @@ void SearchReplace::slotDoSearch()
 void SearchReplace::slotReplace()
 {
 //	if (m_itemMode)
-//		m_doc->view()->slotDoCurs(false);
-    m_doc->m_Selection->clear();
-    m_doc->m_Selection->addItem(m_item);
+	//m_doc->view()->slotDoCurs(false);
+	m_doc->m_Selection->clear();
+	m_doc->m_Selection->addItem(m_item);
 	slotDoReplace();
 	if (m_itemMode)
 	{
@@ -793,12 +793,11 @@ void SearchReplace::slotDoReplace()
 	{
 		QString repl, sear;
 		int cs, cx;
-		int textLen = 0;
+		int textLen = m_item->itemText.lengthOfSelection();
 		if (RText->isChecked())
 		{
 			repl = RTextVal->text();
 			sear = STextVal->text();
-			textLen = m_item->itemText.lengthOfSelection();
 			if (textLen == repl.length())
 			{
 				for (cs = 0; cs < textLen; ++cs)
@@ -821,9 +820,9 @@ void SearchReplace::slotDoReplace()
 				}
 			}
 		}
-		m_item->itemText.deselectAll();
 		if (repl.length() > 0)
 		{
+			m_item->itemText.deselectAll();
 			m_item->itemText.select(m_replStart, repl.length());
 			m_item->itemText.setCursorPosition(m_replStart + repl.length());
 		}

--- a/scribus/ui/search.h
+++ b/scribus/ui/search.h
@@ -8,6 +8,7 @@ for which a new license (GPL+exception) is in place.
 #define SEARCHREPLACE_H
 
 #include <QDialog>
+#include <QMap>
 class QVBoxLayout;
 class QHBoxLayout;
 class QGridLayout;
@@ -33,7 +34,7 @@ class SCRIBUS_API SearchReplace : public QDialog
 	Q_OBJECT
 
 public:
-	SearchReplace( QWidget* parent, ScribusDoc *doc, PageItem* ite, bool mode = true );
+	SearchReplace( QWidget* parent, ScribusDoc *doc, PageItem* ite, bool mode = true, bool CurSelected = true);
 	~SearchReplace() {};
 	virtual void slotDoSearch();
 	virtual void slotDoReplace();
@@ -84,6 +85,7 @@ public:
 	StyleSelect* SEffVal;
 	StyleSelect* REffVal;
 	QCheckBox* Word;
+	QCheckBox* SearchCurrent;
 	QCheckBox* CaseIgnore;
 	QPushButton* DoSearch;
 	QPushButton* DoReplace;
@@ -123,6 +125,7 @@ public slots:
 signals:
 	void NewFont(const QString&);
 	void NewAbs(int);
+	void selectElementByItem(PageItem *ite, bool single = true);
 
 protected:
 	PageItem*   m_item;
@@ -132,7 +135,7 @@ protected:
 	PrefsContext* m_prefs;
 	bool m_notFound;
 	bool m_itemMode;
-
+	bool m_SearchCurrent; // for search current selected text frame
 	QVBoxLayout* SearchReplaceLayout;
 	QHBoxLayout* SelLayout;
 	QGridLayout* SearchLayout;
@@ -146,6 +149,8 @@ protected:
 	int matchesFound;
 	int m_firstMatchPosition;
 
+	// to map each item to a page number
+	QMap<int, QList<PageItem*>> ItemsPageNum;
 };
 
 #endif // SEARCHREPLACE_H

--- a/scribus/ui/search.h
+++ b/scribus/ui/search.h
@@ -125,7 +125,6 @@ public slots:
 signals:
 	void NewFont(const QString&);
 	void NewAbs(int);
-	void selectElementByItem(PageItem *ite, bool single = true);
 
 protected:
 	PageItem*   m_item;


### PR DESCRIPTION
** Ignore diacritics in search dialog in text frame & story editor:
- now you can search for text with ignore diacritics & kashida option,
implemented by using ICU nonspacing-mark category.
- replace text also will consider  diacritics & kashida.
- fix search in linked frames.

** adding Search All functionality
Now you can search & replace in all text frames in scribus document. The
search algorithm is to start from selected text frame, if there is no
text frame selected select the first text frame in the current page, if
not, find the first text frame from next pages, if reaching the end of
the document start searching from the first page.

We add option to search only in current selected text frame.